### PR TITLE
Update token_transfers.js

### DIFF
--- a/lib/cache_multi_management/token_transfers.js
+++ b/lib/cache_multi_management/token_transfers.js
@@ -43,7 +43,7 @@ TokenTransfersCacheKlass.prototype.setCacheKeys = function () {
 
   oThis.cacheKeys = {};
   for (var i = 0; i < oThis.ids.length; i++) {
-    oThis.cacheKeys[oThis._cacheKeyPrefix() + "cmm_trh_" + oThis.ids[i]] = oThis.ids[i];
+    oThis.cacheKeys[oThis._cacheKeyPrefix() + "cmm_tkt_" + oThis.ids[i]] = oThis.ids[i];
   }
 
   return oThis.cacheKeys;


### PR DESCRIPTION
The cache prefix was similar to Transaction hash Cache class. which was causing dangling of cache.
changed it to unique prefix.